### PR TITLE
Add normalization for multi-row INSERT statements and enforce single INSERT

### DIFF
--- a/src/sql_assignment_generator/assignments/dataset/dataset.py
+++ b/src/sql_assignment_generator/assignments/dataset/dataset.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from collections.abc import Sequence
 from dataclasses import dataclass
 import dav_tools
@@ -11,6 +12,57 @@ from ... import llm
 from ...constraints import SchemaConstraint, schema as schema_constraints
 from ...exceptions import SQLParsingError, ConstraintValidationError, DatasetGenerationError
 from ...translatable_text import TranslatableText
+
+
+def _normalize_inserts(parsed_inserts: list[exp.Insert], sql_dialect: str) -> list[str]:
+    '''
+    Merge multiple INSERT statements for the same table into a single multi-row INSERT.
+    Returns the resulting list of SQL strings.
+    '''
+    grouped: OrderedDict[str, list[exp.Insert]] = OrderedDict()
+    for insert in parsed_inserts:
+        table_name = insert.this.this.name.lower()
+        grouped.setdefault(table_name, []).append(insert)
+
+    result = []
+    for table_name, inserts in grouped.items():
+        if len(inserts) == 1:
+            result.append(f'{inserts[0].sql(pretty=True, dialect=sql_dialect)};')
+        else:
+            # Check that all INSERTs have matching column lists before merging
+            first = inserts[0]
+            first_columns = (
+                tuple(col.sql() for col in first.this.expressions)
+                if isinstance(first.this, exp.Schema)
+                else None
+            )
+            columns_match = all(
+                (
+                    isinstance(ins.this, exp.Schema)
+                    and tuple(col.sql() for col in ins.this.expressions) == first_columns
+                )
+                if first_columns is not None
+                else not isinstance(ins.this, exp.Schema)
+                for ins in inserts
+            )
+
+            if not columns_match:
+                # Column lists differ — keep separate, let constraint handle it
+                for insert in inserts:
+                    result.append(f'{insert.sql(pretty=True, dialect=sql_dialect)};')
+                continue
+
+            all_rows = []
+            for insert in inserts:
+                values_node = insert.expression
+                if isinstance(values_node, exp.Values):
+                    all_rows.extend(values_node.expressions)
+
+            new_values = exp.Values(expressions=all_rows)
+            merged = exp.Insert(this=first.this, expression=new_values)
+            result.append(f'{merged.sql(pretty=True, dialect=sql_dialect)};')
+
+    return result
 
 
 @dataclass
@@ -68,11 +120,11 @@ class Dataset:
     @staticmethod
     def from_sql(sql_str: str, sql_dialect: str) -> 'Dataset':
         '''Create a Dataset instance from a raw SQL string containing CREATE TABLE and INSERT INTO commands.'''
-    
+
         try:
             parsed = sqlglot.parse(sql_str, read=sql_dialect)
             create_commands = []
-            insert_commands = []
+            insert_asts = []
 
             for statement in parsed:
                 if isinstance(statement, exp.Create):
@@ -80,12 +132,14 @@ class Dataset:
                         continue  # skip non-table creation statements, e.g. CREATE SCHEMA
                     create_commands.append(f'{statement.sql()};')
                 elif isinstance(statement, exp.Insert):
-                    insert_commands.append(f'{statement.sql()};')
+                    insert_asts.append(statement)
 
             if not create_commands:
                 raise ValueError("No CREATE TABLE commands found in the provided SQL string.")
         except Exception as e:
             raise SQLParsingError(f"Error parsing SQL string: {e}", sql_str)
+
+        insert_commands = _normalize_inserts(insert_asts, sql_dialect)
 
         return Dataset(
             create_commands=create_commands,
@@ -157,7 +211,7 @@ class Dataset:
                             ).get(language),
                             create_table
                         )
-                insert_commands = [f'{cmd.sql(pretty=True, dialect=sql_dialect)};' for cmd in parsed_inserts]
+                insert_commands = _normalize_inserts(parsed_inserts, sql_dialect)
 
                 catalog = build_catalog_from_sql('; '.join(cmd.sql() for cmd in parsed_tables))
 

--- a/src/sql_assignment_generator/assignments/dataset/strings.py
+++ b/src/sql_assignment_generator/assignments/dataset/strings.py
@@ -47,6 +47,7 @@ Generate a {sql_dialect} SQL dataset about the following domain: "{domain}".
 MANDATORY CONSTRAINTS:
 - FOREIGN KEY attributes should have the REFERENCES keyword inline (e.g. "col TYPE REFERENCES table_name(column_name)").
 - VARCHAR columns should not have a length specified (e.g. use "col VARCHAR" instead of "col VARCHAR(255)").
+- Each table must have EXACTLY ONE INSERT INTO statement containing ALL rows for that table. Never write multiple INSERT statements for the same table.
 {formatted_constraints}
 
 MANDATORY OUTPUT (JSON) - each line in both lists must correspond to a single table:
@@ -61,12 +62,12 @@ MANDATORY OUTPUT (JSON) - each line in both lists must correspond to a single ta
     ]
 }}
 
-INSERT INTO statements must have following format (Multi-row insert): 
-INSERT INTO tableName(<all columns except SERIAL/AUTO_INCREMENT>) VALUES 
+INSERT INTO statements must have following format (Multi-row insert):
+INSERT INTO tableName(<all columns except SERIAL/AUTO_INCREMENT>) VALUES
     (val_1, val_2, ...),
     (val_n, val_n+1, ...);
 
-For each table, insert at least 5 rows of data.
+For each table, insert at least 5 rows of data. All rows for a table must be in a single INSERT statement.
 Skip any SERIAL/AUTO_INCREMENT columns in the INSERT statements.
 ''',
         it=f'''Genera un dataset SQL {sql_dialect} sul seguente dominio: "{domain}".
@@ -75,6 +76,7 @@ Skip any SERIAL/AUTO_INCREMENT columns in the INSERT statements.
 CONSTRAINT OBBLIGATORIE:
 - Gli attributi FOREIGN KEY devono avere la keyword REFERENCES inline (es. "col TYPE REFERENCES table_name(column_name)").
 - Le colonne VARCHAR non devono avere una lunghezza specificata (es. usa "col VARCHAR" invece di "col VARCHAR(255)").
+- Ogni tabella deve avere ESATTAMENTE UN'istruzione INSERT INTO contenente TUTTE le righe per quella tabella. Non scrivere mai pi\u00f9 istruzioni INSERT per la stessa tabella.
 {formatted_constraints}
 
 OUTPUT OBBLIGATORIO (JSON) - ogni riga in entrambe le liste deve corrispondere a una singola tabella:
@@ -94,7 +96,7 @@ INSERT INTO tableName(<tutte le colonne tranne SERIAL/AUTO_INCREMENT>) VALUES
     (val_1, val_2, ...),
     (val_n, val_n+1, ...);
 
-Per ogni tabella, inserisci almeno 5 righe di dati.
+Per ogni tabella, inserisci almeno 5 righe di dati. Tutte le righe di una tabella devono essere in un'unica istruzione INSERT.
 ''',
     ).get(language)
 

--- a/src/sql_assignment_generator/constraints/query/subquery.py
+++ b/src/sql_assignment_generator/constraints/query/subquery.py
@@ -74,13 +74,13 @@ class Subqueries(QueryConstraint):
             raise ConstraintValidationError(
                 TranslatableText(
                     f'Exercise must require at least {self.min} unnested subqueries, but no SELECT clause has that many unnested subqueries.',
-                    it=f'L\'esercizio deve richiedere almeno {self.min} sottoscrizioni non annidate, ma nessuna clausola SELECT ha quel numero di sottoscrizioni non annidate.'
+                    it=f'L\'esercizio deve richiedere almeno {self.min} subquery non annidate, ma nessuna clausola SELECT ha quel numero di subquery non annidate.'
                 )
             )
         raise ConstraintValidationError(
             TranslatableText(
                 f'Exercise must require between {self.min} and {self.max} unnested subqueries, but no SELECT clause has that many unnested subqueries.',
-                it=f'L\'esercizio deve richiedere tra {self.min} e {self.max} sottoscrizioni non annidate, ma nessuna clausola SELECT ha quel numero di sottoscrizioni non annidate.'
+                it=f'L\'esercizio deve richiedere tra {self.min} e {self.max} subquery non annidate, ma nessuna clausola SELECT ha quel numero di subquery non annidate.'
             )
         )
 
@@ -89,16 +89,16 @@ class Subqueries(QueryConstraint):
         if self.max is None:
             return TranslatableText(
                 f'Exercise must require at least {self.min} unnested subqueries.',
-                it=f'L\'esercizio deve richiedere almeno {self.min} sottoscrizioni non annidate.'
+                it=f'L\'esercizio deve richiedere almeno {self.min} subquery non annidate.'
             )
         if self.min == self.max:
             return TranslatableText(
                 f'Exercise must require exactly {self.min} unnested subqueries.',
-                it=f'L\'esercizio deve richiedere esattamente {self.min} sottoscrizioni non annidate.'
+                it=f'L\'esercizio deve richiedere esattamente {self.min} subquery non annidate.'
             )
         return TranslatableText(
             f'Exercise must require between {self.min} and {self.max} unnested subqueries.',
-            it=f'L\'esercizio deve richiedere tra {self.min} e {self.max} sottoscrizioni non annidate.'
+            it=f'L\'esercizio deve richiedere tra {self.min} e {self.max} subquery non annidate.'
         )
 class NestedSubqueries(QueryConstraint):
     '''Requires the presence of a certain number of subqueries that contain at least one nested subquery.'''
@@ -123,7 +123,7 @@ class NestedSubqueries(QueryConstraint):
             raise ConstraintValidationError(
                 TranslatableText(
                     f'Exercise must require at least {self.min} subqueries containing nested subqueries, but no SELECT clause has that many nested subqueries. Current nesting counts: {nested_counts}',
-                    it=f'L\'esercizio deve richiedere almeno {self.min} sottoscrizioni contenenti sottoscrizioni annidate, ma nessuna clausola SELECT ha quel numero di sottoscrizioni annidate. Conteggio corrente: {nested_counts}'
+                    it=f'L\'esercizio deve richiedere almeno {self.min} subquery contenenti subquery annidate, ma nessuna clausola SELECT ha quel numero di subquery annidate. Conteggio corrente: {nested_counts}'
                 )
             )
         if self.min <= max_nested <= self.max:
@@ -131,7 +131,7 @@ class NestedSubqueries(QueryConstraint):
         raise ConstraintValidationError(
             TranslatableText(
                 f'Exercise must require between {self.min} and {self.max} subqueries containing nested subqueries, but no SELECT clause has that many nested subqueries. Current nesting counts: {nested_counts}',
-                it=f'L\'esercizio deve richiedere tra {self.min} e {self.max} sottoscrizioni contenenti sottoscrizioni annidate, ma nessuna clausola SELECT ha quel numero di sottoscrizioni annidate. Conteggio corrente: {nested_counts}'
+                it=f'L\'esercizio deve richiedere tra {self.min} e {self.max} subquery contenenti subquery annidate, ma nessuna clausola SELECT ha quel numero di subquery annidate. Conteggio corrente: {nested_counts}'
             )
         )
 
@@ -140,14 +140,14 @@ class NestedSubqueries(QueryConstraint):
         if self.max is None:
             return TranslatableText(
                 f'Exercise must require at least {self.min} subqueries containing nested subqueries.',
-                it=f'L\'esercizio deve richiedere almeno {self.min} sottoscrizioni contenenti sottoscrizioni annidate.'
+                it=f'L\'esercizio deve richiedere almeno {self.min} subquery contenenti subquery annidate.'
             )
         if self.min == self.max:
             return TranslatableText(
                 f'Exercise must require exactly {self.min} subqueries containing nested subqueries.',
-                it=f'L\'esercizio deve richiedere esattamente {self.min} sottoscrizioni contenenti sottoscrizioni annidate.'
+                it=f'L\'esercizio deve richiedere esattamente {self.min} subquery contenenti subquery annidate.'
             )
         return TranslatableText(
             f'Exercise must require between {self.min} and {self.max} subqueries containing nested subqueries.',
-            it=f'L\'esercizio deve richiedere tra {self.min} e {self.max} sottoscrizioni contenenti sottoscrizioni annidate.'
+            it=f'L\'esercizio deve richiedere tra {self.min} e {self.max} subquery contenenti subquery annidate.'
         )

--- a/src/sql_assignment_generator/constraints/schema/values.py
+++ b/src/sql_assignment_generator/constraints/schema/values.py
@@ -53,6 +53,38 @@ class MinRows(SchemaConstraint):
     def merge(self, other: SchemaConstraint) -> 'MinRows':
         if not isinstance(other, MinRows):
             raise ConstraintMergeError(self, other)
-        
+
         min_rows = max(self.min, other.min)
         return MinRows(min_=min_rows)
+
+class SingleInsertPerTable(SchemaConstraint):
+    '''Requires that each table has exactly one INSERT statement (multi-row format).'''
+
+    def validate(self, catalog: Catalog, tables_sql: list[exp.Create], values_sql: list[exp.Insert]) -> None:
+        table_insert_counts = Counter()
+
+        for value in values_sql:
+            table_name = value.this.this.name.lower()
+            table_insert_counts[table_name] += 1
+
+        violating_tables = [t for t, c in table_insert_counts.items() if c > 1]
+        if violating_tables:
+            table_list = ', '.join(f'"{t}"' for t in violating_tables)
+            raise ConstraintValidationError(
+                TranslatableText(
+                    f'Tables {table_list} have multiple INSERT statements. Each table must have exactly one multi-row INSERT.',
+                    it=f'Le tabelle {table_list} hanno più istruzioni INSERT. Ogni tabella deve avere esattamente un\'istruzione INSERT multi-riga.'
+                )
+            )
+
+    @property
+    def description(self) -> TranslatableText:
+        return TranslatableText(
+            'Each table must have exactly one INSERT INTO statement with all rows in multi-row format.',
+            it='Ogni tabella deve avere esattamente un\'istruzione INSERT INTO con tutte le righe in formato multi-riga.'
+        )
+
+    def merge(self, other: SchemaConstraint) -> 'SingleInsertPerTable':
+        if not isinstance(other, SingleInsertPerTable):
+            raise ConstraintMergeError(self, other)
+        return SingleInsertPerTable()

--- a/src/sql_assignment_generator/error_requirements/base.py
+++ b/src/sql_assignment_generator/error_requirements/base.py
@@ -18,18 +18,22 @@ class SqlErrorRequirements(ABC):
             return [
                 schema_constraints.tables.MinTables(2),
                 schema_constraints.tables.MinColumns(2, tables=1),
-                schema_constraints.values.MinRows(3)
+                schema_constraints.values.MinRows(3),
+                schema_constraints.values.SingleInsertPerTable(),
             ]
         if difficulty == DifficultyLevel.MEDIUM:
             return [
                 schema_constraints.tables.MinTables(4),
                 schema_constraints.tables.MinColumns(4, tables=2),
-                schema_constraints.values.MinRows(4)]
+                schema_constraints.values.MinRows(4),
+                schema_constraints.values.SingleInsertPerTable(),
+            ]
         if difficulty == DifficultyLevel.HARD:
             return [
                 schema_constraints.tables.MinTables(6),
                 schema_constraints.tables.MinColumns(5, tables=3),
-                schema_constraints.values.MinRows(5)
+                schema_constraints.values.MinRows(5),
+                schema_constraints.values.SingleInsertPerTable(),
             ]
 
     def exercise_constraints(self, difficulty: DifficultyLevel) -> list[QueryConstraint]:

--- a/tests/constraints/schema/test_values.py
+++ b/tests/constraints/schema/test_values.py
@@ -2,8 +2,8 @@ import pytest
 import sqlglot
 from sqlglot import exp
 from sqlscope import build_catalog_from_sql
-from sql_assignment_generator.constraints.schema.values import MinRows
-from sql_assignment_generator.exceptions import ConstraintValidationError
+from sql_assignment_generator.constraints.schema.values import MinRows, SingleInsertPerTable
+from sql_assignment_generator.exceptions import ConstraintMergeError, ConstraintValidationError
 
 from . import prepare_catalog
 
@@ -73,6 +73,84 @@ def test_min_rows_merge():
     c1 = MinRows(min_=3)
     c2 = MinRows(min_=5)
     merged = c1.merge(c2)
-    
+
     assert merged.min == 5
     assert isinstance(merged, MinRows)
+
+
+# =================================================================
+# TEST SINGLE INSERT PER TABLE - PASS
+# =================================================================
+
+@pytest.mark.parametrize("create_sqls, insert_sqls", [
+    # Single table with one multi-row INSERT
+    (
+        ["CREATE TABLE t1 (id INT PRIMARY KEY)"],
+        ["INSERT INTO t1 (id) VALUES (1), (2), (3)"]
+    ),
+    # Two tables, one INSERT each
+    (
+        ["CREATE TABLE t1 (id INT PRIMARY KEY)", "CREATE TABLE t2 (id INT PRIMARY KEY)"],
+        ["INSERT INTO t1 (id) VALUES (1), (2)", "INSERT INTO t2 (id) VALUES (10), (20)"]
+    ),
+    # Empty insert list — no tables to check
+    (
+        ["CREATE TABLE t1 (id INT PRIMARY KEY)"],
+        []
+    ),
+    # INSERT without column list
+    (
+        ["CREATE TABLE t1 (id INT PRIMARY KEY)"],
+        ["INSERT INTO t1 VALUES (1), (2), (3)"]
+    ),
+])
+def test_single_insert_per_table_pass(create_sqls, insert_sqls):
+    catalog, tables_ast, values_ast = prepare_catalog(create_sqls, insert_sqls)
+    constraint = SingleInsertPerTable()
+    constraint.validate(catalog, tables_ast, values_ast)
+
+
+# =================================================================
+# TEST SINGLE INSERT PER TABLE - FAIL
+# =================================================================
+
+@pytest.mark.parametrize("create_sqls, insert_sqls", [
+    # One table with two separate INSERTs
+    (
+        ["CREATE TABLE t1 (id INT PRIMARY KEY)"],
+        ["INSERT INTO t1 (id) VALUES (1)", "INSERT INTO t1 (id) VALUES (2)"]
+    ),
+    # Two tables, one has duplicates
+    (
+        ["CREATE TABLE t1 (id INT PRIMARY KEY)", "CREATE TABLE t2 (id INT PRIMARY KEY)"],
+        ["INSERT INTO t1 (id) VALUES (1)", "INSERT INTO t2 (id) VALUES (10)", "INSERT INTO t2 (id) VALUES (20)"]
+    ),
+    # Three INSERTs for the same table
+    (
+        ["CREATE TABLE t1 (id INT PRIMARY KEY)"],
+        ["INSERT INTO t1 (id) VALUES (1)", "INSERT INTO t1 (id) VALUES (2)", "INSERT INTO t1 (id) VALUES (3)"]
+    ),
+])
+def test_single_insert_per_table_fail(create_sqls, insert_sqls):
+    catalog, tables_ast, values_ast = prepare_catalog(create_sqls, insert_sqls)
+    constraint = SingleInsertPerTable()
+    with pytest.raises(ConstraintValidationError):
+        constraint.validate(catalog, tables_ast, values_ast)
+
+
+# =================================================================
+# TEST SINGLE INSERT PER TABLE - MERGE
+# =================================================================
+
+def test_single_insert_per_table_merge():
+    c1 = SingleInsertPerTable()
+    c2 = SingleInsertPerTable()
+    merged = c1.merge(c2)
+
+    assert isinstance(merged, SingleInsertPerTable)
+
+def test_single_insert_per_table_merge_wrong_type():
+    c1 = SingleInsertPerTable()
+    c2 = MinRows(min_=3)
+    with pytest.raises(ConstraintMergeError):
+        c1.merge(c2)


### PR DESCRIPTION
…INSERT per table constraint

- Implemented _normalize_inserts function to merge multiple INSERT statements for the same table into a single multi-row INSERT.
- Updated Dataset class to utilize the new normalization function.
- Added SingleInsertPerTable constraint to ensure each table has exactly one multi-row INSERT statement.
- Enhanced error messages in existing constraints for clarity.
- Added tests for SingleInsertPerTable constraint validation and merging.