### PR TITLE
enhance prompts and add function to check for min one rows in the output

### DIFF
--- a/src/sql_assignment_generator/__init__.py
+++ b/src/sql_assignment_generator/__init__.py
@@ -12,10 +12,138 @@ from .domains import random_domain
 from .assignments import Assignment, Dataset, Exercise
 from .constraints import SchemaConstraint, QueryConstraint
 from .error_requirements import SqlErrorRequirements, ERROR_REQUIREMENTS_MAP
-from .exceptions import ExerciseGenerationError
+from .exceptions import ExerciseGenerationError, SQLParsingError
+from .query_executor import create_db, execute_query, validate_assignment
+from .assignments.dataset import strings as dataset_strings
 
 import dav_tools
 from sql_error_taxonomy import SqlErrors
+import sqlglot
+
+
+def _validate_and_fix_queries(
+        assignment: Assignment,
+        sql_dialect: str,
+        language: str,
+        max_regeneration_attempts: int,
+    ) -> Assignment:
+    '''Execute all exercises, regenerate data for queries returning no results.'''
+
+    results = validate_assignment(assignment, sql_dialect)
+
+    # Find exercises that return no results (and not due to execution errors)
+    failing_indices = [
+        i for i, (_, result) in enumerate(results)
+        if not result.has_results and result.success
+    ]
+
+    if not failing_indices:
+        return assignment
+
+    dav_tools.messages.warning(
+        f'{len(failing_indices)} exercise(s) return no results. Attempting to regenerate sample data.'
+    )
+
+    dataset = assignment.dataset
+    exercises = assignment.exercises
+    schema_sql = '\n'.join(dataset.create_commands)
+
+    for idx in failing_indices:
+        exercise = exercises[idx]
+        query_sql = exercise.solutions[0].sql
+        current_data = '\n'.join(dataset.insert_commands)
+
+        regenerated = False
+
+        for attempt in range(max_regeneration_attempts):
+            # Ask LLM to regenerate INSERT data
+            from . import llm
+
+            prompt = dataset_strings.prompt_regenerate_data(
+                schema_sql=schema_sql,
+                failing_query=query_sql,
+                current_data=current_data,
+                sql_dialect=sql_dialect,
+                language=language,
+            )
+
+            messages = llm.Message()
+            messages.add_message_user(prompt)
+
+            try:
+                answer = llm.generate_answer(messages, json_format=llm.models.InsertData)
+                assert isinstance(answer, llm.models.InsertData)
+
+                # Parse and normalize new INSERT commands
+                new_inserts = []
+                for cmd in answer.insert_commands:
+                    try:
+                        parsed = sqlglot.parse_one(cmd, read=sql_dialect)
+                        new_inserts.append(parsed)
+                    except Exception:
+                        new_inserts.append(cmd)
+
+                # Normalize using the existing function
+                from .assignments.dataset.dataset import _normalize_inserts
+                new_insert_commands = _normalize_inserts(
+                    [i for i in new_inserts if hasattr(i, 'sql')],
+                    sql_dialect
+                )
+
+                if not new_insert_commands:
+                    continue
+
+                # Try the new dataset
+                new_dataset = dataset.with_inserts(new_insert_commands)
+                conn = create_db(new_dataset, sql_dialect)
+
+                # Verify the failing query now returns results
+                failing_result = execute_query(conn, query_sql, sql_dialect)
+                if not failing_result.has_results:
+                    conn.close()
+                    dav_tools.messages.warning(
+                        f'{exercise.title}: Regenerated data still returns no results (attempt {attempt + 1}).'
+                    )
+                    continue
+
+                # Verify ALL other exercises still work
+                all_pass = True
+                for other_idx, other_exercise in enumerate(exercises):
+                    if other_idx == idx:
+                        continue
+                    other_result = execute_query(conn, other_exercise.solutions[0].sql, sql_dialect)
+                    if other_result.success and not other_result.has_results:
+                        all_pass = False
+                        dav_tools.messages.warning(
+                            f'{other_exercise.title}: Broken by regenerated data.'
+                        )
+                        break
+
+                conn.close()
+
+                if all_pass:
+                    dataset = new_dataset
+                    regenerated = True
+                    dav_tools.messages.success(
+                        f'{exercise.title}: Data regenerated successfully.'
+                    )
+                    break
+                else:
+                    dav_tools.messages.warning(
+                        f'{exercise.title}: Regenerated data broke other exercises (attempt {attempt + 1}).'
+                    )
+
+            except Exception as e:
+                dav_tools.messages.error(
+                    f'{exercise.title}: Error regenerating data (attempt {attempt + 1}): {e}'
+                )
+
+        if not regenerated:
+            dav_tools.messages.warning(
+                f'{exercise.title}: Could not regenerate data after {max_regeneration_attempts} attempts. Keeping original data.'
+            )
+
+    return Assignment(dataset=dataset, exercises=exercises)
 
 
 def generate_assignment(
@@ -30,7 +158,9 @@ def generate_assignment(
         max_dataset_attempts: int = 3,
         max_exercise_attempts: int = 3,
         max_unique_attempts: int = 3,
-        max_workers: int | None = None
+        max_workers: int | None = None,
+        validate_queries: bool = True,
+        max_regeneration_attempts: int = 2,
     ) -> Assignment:
     '''
     Generate SQL assignments based on the given SQL errors and their corresponding difficulty levels.
@@ -209,7 +339,18 @@ def generate_assignment(
     else:
         dav_tools.messages.success(f'Successfully generated all {len(exercises)} exercises. Unsupported: {len(errors) - len(supported_errors)}.')
 
-    return Assignment(
+    assignment = Assignment(
         dataset=dataset,
         exercises=exercises
     )
+
+    # Post-generation validation: execute queries and check for empty results
+    if validate_queries and exercises:
+        assignment = _validate_and_fix_queries(
+            assignment=assignment,
+            sql_dialect=sql_dialect,
+            language=language,
+            max_regeneration_attempts=max_regeneration_attempts,
+        )
+
+    return assignment

--- a/src/sql_assignment_generator/__init__.py
+++ b/src/sql_assignment_generator/__init__.py
@@ -13,8 +13,9 @@ from .assignments import Assignment, Dataset, Exercise
 from .constraints import SchemaConstraint, QueryConstraint
 from .error_requirements import SqlErrorRequirements, ERROR_REQUIREMENTS_MAP
 from .exceptions import ExerciseGenerationError, SQLParsingError
-from .query_executor import create_db, execute_query, validate_assignment
+from .query_executor import execute_query, validate_assignment
 from .assignments.dataset import strings as dataset_strings
+from .db import get_database, QueryExecutionError
 
 import dav_tools
 from sql_error_taxonomy import SqlErrors
@@ -26,10 +27,14 @@ def _validate_and_fix_queries(
         sql_dialect: str,
         language: str,
         max_regeneration_attempts: int,
+        db_host: str,
+        db_port: int,
+        db_user: str,
+        db_password: str,
     ) -> Assignment:
     '''Execute all exercises, regenerate data for queries returning no results.'''
 
-    results = validate_assignment(assignment, sql_dialect)
+    results = validate_assignment(assignment, sql_dialect, db_host, db_port, db_user, db_password)
 
     # Find exercises that return no results (and not due to execution errors)
     failing_indices = [
@@ -95,31 +100,37 @@ def _validate_and_fix_queries(
 
                 # Try the new dataset
                 new_dataset = dataset.with_inserts(new_insert_commands)
-                conn = create_db(new_dataset, sql_dialect)
 
-                # Verify the failing query now returns results
-                failing_result = execute_query(conn, query_sql, sql_dialect)
-                if not failing_result.has_results:
-                    conn.close()
-                    dav_tools.messages.warning(
-                        f'{exercise.title}: Regenerated data still returns no results (attempt {attempt + 1}).'
-                    )
-                    continue
-
-                # Verify ALL other exercises still work
-                all_pass = True
-                for other_idx, other_exercise in enumerate(exercises):
-                    if other_idx == idx:
-                        continue
-                    other_result = execute_query(conn, other_exercise.solutions[0].sql, sql_dialect)
-                    if other_result.success and not other_result.has_results:
-                        all_pass = False
+                # Verify against the real DBMS
+                with get_database(db_host, db_port, db_user, db_password, sql_dialect) as db:
+                    try:
+                        db.execute(new_dataset.to_sql_no_context())
+                    except QueryExecutionError:
                         dav_tools.messages.warning(
-                            f'{other_exercise.title}: Broken by regenerated data.'
+                            f'{exercise.title}: Regenerated data failed to load (attempt {attempt + 1}).'
                         )
-                        break
+                        continue
 
-                conn.close()
+                    # Verify the failing query now returns results
+                    failing_result = execute_query(db, query_sql)
+                    if not failing_result.has_results:
+                        dav_tools.messages.warning(
+                            f'{exercise.title}: Regenerated data still returns no results (attempt {attempt + 1}).'
+                        )
+                        continue
+
+                    # Verify ALL other exercises still work
+                    all_pass = True
+                    for other_idx, other_exercise in enumerate(exercises):
+                        if other_idx == idx:
+                            continue
+                        other_result = execute_query(db, other_exercise.solutions[0].sql)
+                        if other_result.success and not other_result.has_results:
+                            all_pass = False
+                            dav_tools.messages.warning(
+                                f'{other_exercise.title}: Broken by regenerated data.'
+                            )
+                            break
 
                 if all_pass:
                     dataset = new_dataset
@@ -367,6 +378,10 @@ def generate_assignment(
             sql_dialect=sql_dialect,
             language=language,
             max_regeneration_attempts=max_regeneration_attempts,
+            db_host=db_host,
+            db_port=db_port,
+            db_user=db_user,
+            db_password=db_password,
         )
 
     return assignment

--- a/src/sql_assignment_generator/assignments/dataset/dataset.py
+++ b/src/sql_assignment_generator/assignments/dataset/dataset.py
@@ -98,6 +98,14 @@ class Dataset:
         
         return self._catalog_cache
     
+    def with_inserts(self, insert_commands: list[str]) -> 'Dataset':
+        '''Return a new Dataset with replaced INSERT commands and invalidated catalog cache.'''
+        return Dataset(
+            create_commands=self.create_commands,
+            insert_commands=insert_commands,
+            domain=self.domain,
+        )
+
     def to_sql_no_context(self) -> str:
         '''Generate the SQL commands to create and populate the dataset without schema context.'''
 

--- a/src/sql_assignment_generator/assignments/dataset/strings.py
+++ b/src/sql_assignment_generator/assignments/dataset/strings.py
@@ -105,3 +105,65 @@ def feedback_constraint_violations(errors: list[str], * , language: str) -> str:
         f"The previous JSON output was rejected because the SQL violated these constraints: {', '.join(errors)}\n Regenerate the JSON correcting the SQL to satisfy all mandatory constraints.",
         it=f"Il precedente output JSON è stato rifiutato perché il SQL ha violato queste constraint: {', '.join(errors)}\n Rigenera il JSON correggendo il SQL per soddisfare tutte le constraint obbligatorie."
     ).get(language)
+
+
+def prompt_regenerate_data(
+        schema_sql: str,
+        failing_query: str,
+        current_data: str,
+        *,
+        sql_dialect: str,
+        language: str
+    ) -> str:
+    return TranslatableText(
+        f'''The following SQL query returns no results when executed against the dataset below. Generate new INSERT data that makes this query return at least one row.
+
+### SCHEMA ###
+{schema_sql}
+
+### FAILING QUERY ###
+{failing_query}
+
+### CURRENT INSERT DATA ###
+{current_data}
+
+Generate a complete set of INSERT INTO statements for ALL tables (replacing the current data). The new data must:
+- Be compatible with the schema above
+- Make the failing query return at least one row
+- Follow multi-row INSERT format (one INSERT per table)
+- Contain at least 5 rows per table
+
+MANDATORY OUTPUT (JSON):
+{{
+    "insert_commands": [
+        "INSERT INTO t1(...) VALUES (...), (...), ...;",
+        "INSERT INTO t2(...) VALUES (...), (...), ...;"
+    ]
+}}
+''',
+        it=f'''La seguente query SQL non restituisce risultati quando eseguita sul dataset sottostante. Genera nuovi dati INSERT che facciano restituire almeno una riga a questa query.
+
+### SCHEMA ###
+{schema_sql}
+
+### QUERY CHE FALLISCE ###
+{failing_query}
+
+### DATI INSERT CORRENTI ###
+{current_data}
+
+Genera un set completo di istruzioni INSERT INTO per TUTTE le tabelle (sostituendo i dati correnti). I nuovi dati devono:
+- Essere compatibili con lo schema sopra
+- Far restituire almeno una riga alla query che fallisce
+- Seguire il formato INSERT multi-riga (un INSERT per tabella)
+- Contenere almeno 5 righe per tabella
+
+OUTPUT OBBLIGATORIO (JSON):
+{{
+    "insert_commands": [
+        "INSERT INTO t1(...) VALUES (...), (...), ...;",
+        "INSERT INTO t2(...) VALUES (...), (...), ...;"
+    ]
+}}
+'''
+    ).get(language)

--- a/src/sql_assignment_generator/llm/models.py
+++ b/src/sql_assignment_generator/llm/models.py
@@ -44,3 +44,9 @@ Insert Value:
 class RemoveHints(BaseModel):
     '''JSON model for removing hints from a request'''
     request_without_hints: str
+
+
+@dataclass
+class InsertData(BaseModel):
+    '''JSON model for regenerated INSERT data'''
+    insert_commands: list[str]

--- a/src/sql_assignment_generator/query_executor.py
+++ b/src/sql_assignment_generator/query_executor.py
@@ -1,0 +1,93 @@
+'''Execute SQL queries against a dataset using an in-memory SQLite database.'''
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+import sqlglot
+
+from .assignments import Assignment, Dataset, Exercise
+
+
+@dataclass
+class ExecutionResult:
+    '''Result of executing a single query.'''
+
+    rows: list[tuple]
+    columns: list[str]
+    error: str | None = None
+
+    @property
+    def has_results(self) -> bool:
+        return self.error is None and len(self.rows) > 0
+
+    @property
+    def success(self) -> bool:
+        return self.error is None
+
+
+def _transpile(sql: str, read_dialect: str) -> str | None:
+    '''Transpile SQL from the source dialect to SQLite. Returns None on failure.'''
+    try:
+        results = sqlglot.transpile(sql, read=read_dialect, write='sqlite')
+        return results[0] if results else None
+    except Exception:
+        return None
+
+
+def create_db(dataset: Dataset, sql_dialect: str) -> sqlite3.Connection:
+    '''Create an in-memory SQLite database from a dataset's CREATE and INSERT commands.'''
+    conn = sqlite3.connect(':memory:')
+
+    for cmd in dataset.create_commands:
+        sqlite_sql = _transpile(cmd, sql_dialect)
+        if sqlite_sql is None:
+            sqlite_sql = cmd  # fall back to original SQL
+        try:
+            conn.execute(sqlite_sql)
+        except Exception:
+            pass  # skip untranslatable statements
+
+    for cmd in dataset.insert_commands:
+        sqlite_sql = _transpile(cmd, sql_dialect)
+        if sqlite_sql is None:
+            sqlite_sql = cmd
+        try:
+            conn.execute(sqlite_sql)
+        except Exception:
+            pass
+
+    conn.commit()
+    return conn
+
+
+def execute_query(conn: sqlite3.Connection, query_sql: str, sql_dialect: str) -> ExecutionResult:
+    '''Execute a single query and return the result.'''
+    sqlite_sql = _transpile(query_sql, sql_dialect)
+    if sqlite_sql is None:
+        sqlite_sql = query_sql
+    try:
+        cursor = conn.execute(sqlite_sql)
+        rows = cursor.fetchall()
+        columns = [desc[0] for desc in cursor.description] if cursor.description else []
+        return ExecutionResult(rows=rows, columns=columns)
+    except Exception as e:
+        return ExecutionResult(rows=[], columns=[], error=str(e))
+
+
+def validate_assignment(assignment: Assignment, sql_dialect: str) -> list[tuple[Exercise, ExecutionResult]]:
+    '''Execute all exercises' solutions and return results.
+
+    Returns a list of (exercise, result) tuples in the same order as exercises.
+    '''
+    results: list[tuple[Exercise, ExecutionResult]] = []
+    conn = create_db(assignment.dataset, sql_dialect)
+
+    for exercise in assignment.exercises:
+        query_sql = exercise.solutions[0].sql
+        result = execute_query(conn, query_sql, sql_dialect)
+        results.append((exercise, result))
+
+    conn.close()
+    return results

--- a/src/sql_assignment_generator/query_executor.py
+++ b/src/sql_assignment_generator/query_executor.py
@@ -1,13 +1,11 @@
-'''Execute SQL queries against a dataset using an in-memory SQLite database.'''
+'''Execute SQL queries against a dataset using the configured DBMS.'''
 
 from __future__ import annotations
 
-import sqlite3
 from dataclasses import dataclass
 
-import sqlglot
-
-from .assignments import Assignment, Dataset, Exercise
+from .assignments import Assignment, Exercise
+from .db import get_database, Database, QueryExecutionError
 
 
 @dataclass
@@ -15,7 +13,6 @@ class ExecutionResult:
     '''Result of executing a single query.'''
 
     rows: list[tuple]
-    columns: list[str]
     error: str | None = None
 
     @property
@@ -27,67 +24,45 @@ class ExecutionResult:
         return self.error is None
 
 
-def _transpile(sql: str, read_dialect: str) -> str | None:
-    '''Transpile SQL from the source dialect to SQLite. Returns None on failure.'''
-    try:
-        results = sqlglot.transpile(sql, read=read_dialect, write='sqlite')
-        return results[0] if results else None
-    except Exception:
-        return None
-
-
-def create_db(dataset: Dataset, sql_dialect: str) -> sqlite3.Connection:
-    '''Create an in-memory SQLite database from a dataset's CREATE and INSERT commands.'''
-    conn = sqlite3.connect(':memory:')
-
-    for cmd in dataset.create_commands:
-        sqlite_sql = _transpile(cmd, sql_dialect)
-        if sqlite_sql is None:
-            sqlite_sql = cmd  # fall back to original SQL
-        try:
-            conn.execute(sqlite_sql)
-        except Exception:
-            pass  # skip untranslatable statements
-
-    for cmd in dataset.insert_commands:
-        sqlite_sql = _transpile(cmd, sql_dialect)
-        if sqlite_sql is None:
-            sqlite_sql = cmd
-        try:
-            conn.execute(sqlite_sql)
-        except Exception:
-            pass
-
-    conn.commit()
-    return conn
-
-
-def execute_query(conn: sqlite3.Connection, query_sql: str, sql_dialect: str) -> ExecutionResult:
+def execute_query(db: Database, query_sql: str) -> ExecutionResult:
     '''Execute a single query and return the result.'''
-    sqlite_sql = _transpile(query_sql, sql_dialect)
-    if sqlite_sql is None:
-        sqlite_sql = query_sql
     try:
-        cursor = conn.execute(sqlite_sql)
-        rows = cursor.fetchall()
-        columns = [desc[0] for desc in cursor.description] if cursor.description else []
-        return ExecutionResult(rows=rows, columns=columns)
-    except Exception as e:
-        return ExecutionResult(rows=[], columns=[], error=str(e))
+        rows = db.execute(query_sql)
+        return ExecutionResult(rows=rows)
+    except QueryExecutionError as e:
+        return ExecutionResult(rows=[], error=str(e))
 
 
-def validate_assignment(assignment: Assignment, sql_dialect: str) -> list[tuple[Exercise, ExecutionResult]]:
-    '''Execute all exercises' solutions and return results.
+def validate_assignment(
+        assignment: Assignment,
+        sql_dialect: str,
+        db_host: str,
+        db_port: int,
+        db_user: str,
+        db_password: str,
+    ) -> list[tuple[Exercise, ExecutionResult]]:
+    '''Execute all exercises' solutions against the dataset and return results.
 
-    Returns a list of (exercise, result) tuples in the same order as exercises.
+    Creates a temporary schema on the DBMS, loads the dataset, executes each
+    exercise query, then cleans up the schema.
     '''
     results: list[tuple[Exercise, ExecutionResult]] = []
-    conn = create_db(assignment.dataset, sql_dialect)
 
-    for exercise in assignment.exercises:
-        query_sql = exercise.solutions[0].sql
-        result = execute_query(conn, query_sql, sql_dialect)
-        results.append((exercise, result))
+    with get_database(db_host, db_port, db_user, db_password, sql_dialect) as db:
+        # Load dataset into the temporary schema
+        dataset_sql = assignment.dataset.to_sql_no_context()
+        try:
+            db.execute(dataset_sql)
+        except QueryExecutionError:
+            # Dataset itself failed to load — all queries will fail
+            for exercise in assignment.exercises:
+                results.append((exercise, ExecutionResult(rows=[], error='Dataset failed to load')))
+            return results
 
-    conn.close()
+        # Execute each exercise query
+        for exercise in assignment.exercises:
+            query_sql = exercise.solutions[0].sql
+            result = execute_query(db, query_sql)
+            results.append((exercise, result))
+
     return results

--- a/tests/test_query_executor.py
+++ b/tests/test_query_executor.py
@@ -1,0 +1,223 @@
+import pytest
+from sql_assignment_generator.query_executor import (
+    create_db,
+    execute_query,
+    validate_assignment,
+    ExecutionResult,
+)
+from sql_assignment_generator.assignments import Assignment, Dataset, Exercise
+from sql_assignment_generator.difficulty_level import DifficultyLevel
+from sql_error_taxonomy import SqlErrors
+from sqlscope import Query
+
+
+def _make_dataset(create_sqls: list[str], insert_sqls: list[str]) -> Dataset:
+    '''Create a Dataset from raw SQL strings.'''
+    return Dataset.from_sql(
+        sql_str='\n'.join(create_sqls + insert_sqls),
+        sql_dialect='postgres',
+    )
+
+
+# =================================================================
+# CREATE DB
+# =================================================================
+
+class TestCreateDb:
+
+    def test_basic_schema_and_data(self):
+        dataset = _make_dataset(
+            ['CREATE TABLE t1 (id INT PRIMARY KEY, name VARCHAR);'],
+            ["INSERT INTO t1 (id, name) VALUES (1, 'Alice'), (2, 'Bob');"],
+        )
+        conn = create_db(dataset, 'postgres')
+        rows = conn.execute('SELECT * FROM t1').fetchall()
+        conn.close()
+        assert len(rows) == 2
+        assert rows[0] == (1, 'Alice')
+
+    def test_multiple_tables(self):
+        dataset = _make_dataset(
+            [
+                'CREATE TABLE t1 (id INT PRIMARY KEY);',
+                'CREATE TABLE t2 (id INT PRIMARY KEY, name VARCHAR);',
+            ],
+            [
+                'INSERT INTO t1 (id) VALUES (1), (2);',
+                "INSERT INTO t2 (id, name) VALUES (1, 'x'), (2, 'y');",
+            ],
+        )
+        conn = create_db(dataset, 'postgres')
+        t1_rows = conn.execute('SELECT * FROM t1').fetchall()
+        t2_rows = conn.execute('SELECT * FROM t2').fetchall()
+        conn.close()
+        assert len(t1_rows) == 2
+        assert len(t2_rows) == 2
+
+    def test_foreign_key(self):
+        dataset = _make_dataset(
+            [
+                'CREATE TABLE dept (id INT PRIMARY KEY, name VARCHAR);',
+                'CREATE TABLE emp (id INT PRIMARY KEY, dept_id INT REFERENCES dept(id));',
+            ],
+            [
+                "INSERT INTO dept (id, name) VALUES (1, 'Engineering');",
+                "INSERT INTO emp (id, dept_id) VALUES (1, 1), (2, 1);",
+            ],
+        )
+        conn = create_db(dataset, 'postgres')
+        rows = conn.execute('SELECT * FROM emp').fetchall()
+        conn.close()
+        assert len(rows) == 2
+
+
+# =================================================================
+# EXECUTE QUERY
+# =================================================================
+
+class TestExecuteQuery:
+
+    def test_returns_results(self):
+        dataset = _make_dataset(
+            ['CREATE TABLE t1 (id INT PRIMARY KEY, val INT);'],
+            ['INSERT INTO t1 (id, val) VALUES (1, 10), (2, 20), (3, 30);'],
+        )
+        conn = create_db(dataset, 'postgres')
+        result = execute_query(conn, 'SELECT * FROM t1 WHERE val > 15', 'postgres')
+        conn.close()
+        assert result.success
+        assert result.has_results
+        assert len(result.rows) == 2
+
+    def test_returns_empty(self):
+        dataset = _make_dataset(
+            ['CREATE TABLE t1 (id INT PRIMARY KEY, val INT);'],
+            ['INSERT INTO t1 (id, val) VALUES (1, 10), (2, 20);'],
+        )
+        conn = create_db(dataset, 'postgres')
+        result = execute_query(conn, 'SELECT * FROM t1 WHERE val > 100', 'postgres')
+        conn.close()
+        assert result.success
+        assert not result.has_results
+        assert len(result.rows) == 0
+
+    def test_query_error(self):
+        dataset = _make_dataset(
+            ['CREATE TABLE t1 (id INT PRIMARY KEY);'],
+            ['INSERT INTO t1 (id) VALUES (1);'],
+        )
+        conn = create_db(dataset, 'postgres')
+        result = execute_query(conn, 'SELECT * FROM nonexistent_table', 'postgres')
+        conn.close()
+        assert not result.success
+        assert result.error is not None
+
+    def test_columns_returned(self):
+        dataset = _make_dataset(
+            ['CREATE TABLE t1 (id INT PRIMARY KEY, name VARCHAR);'],
+            ["INSERT INTO t1 (id, name) VALUES (1, 'Alice');"],
+        )
+        conn = create_db(dataset, 'postgres')
+        result = execute_query(conn, 'SELECT id, name FROM t1', 'postgres')
+        conn.close()
+        assert result.columns == ['id', 'name']
+
+
+# =================================================================
+# EXECUTION RESULT
+# =================================================================
+
+class TestExecutionResult:
+
+    def test_has_results_true(self):
+        r = ExecutionResult(rows=[(1,)], columns=['id'])
+        assert r.has_results
+        assert r.success
+
+    def test_has_results_false_empty(self):
+        r = ExecutionResult(rows=[], columns=[])
+        assert not r.has_results
+        assert r.success
+
+    def test_has_results_false_error(self):
+        r = ExecutionResult(rows=[], columns=[], error='some error')
+        assert not r.has_results
+        assert not r.success
+
+
+# =================================================================
+# VALIDATE ASSIGNMENT
+# =================================================================
+
+class TestValidateAssignment:
+
+    def test_all_exercises_return_results(self):
+        dataset = _make_dataset(
+            ['CREATE TABLE t1 (id INT PRIMARY KEY, val INT);'],
+            ['INSERT INTO t1 (id, val) VALUES (1, 10), (2, 20);'],
+        )
+        catalog = dataset.catalog
+        query = Query('SELECT * FROM t1 WHERE val > 5', catalog=catalog)
+        exercise = Exercise(
+            title='Test',
+            request='Get all rows with val > 5',
+            solutions=[query],
+            difficulty=DifficultyLevel.EASY,
+            error=SqlErrors.SYN_1_OMITTING_CORRELATION_NAMES,
+        )
+        assignment = Assignment(dataset=dataset, exercises=[exercise])
+        results = validate_assignment(assignment, 'postgres')
+        assert len(results) == 1
+        _, result = results[0]
+        assert result.has_results
+
+    def test_exercise_returns_no_results(self):
+        dataset = _make_dataset(
+            ['CREATE TABLE t1 (id INT PRIMARY KEY, val INT);'],
+            ['INSERT INTO t1 (id, val) VALUES (1, 10), (2, 20);'],
+        )
+        catalog = dataset.catalog
+        query = Query('SELECT * FROM t1 WHERE val > 100', catalog=catalog)
+        exercise = Exercise(
+            title='Test',
+            request='Get all rows with val > 100',
+            solutions=[query],
+            difficulty=DifficultyLevel.EASY,
+            error=SqlErrors.SYN_1_OMITTING_CORRELATION_NAMES,
+        )
+        assignment = Assignment(dataset=dataset, exercises=[exercise])
+        results = validate_assignment(assignment, 'postgres')
+        assert len(results) == 1
+        _, result = results[0]
+        assert result.success
+        assert not result.has_results
+
+    def test_multiple_exercises_mixed(self):
+        dataset = _make_dataset(
+            ['CREATE TABLE t1 (id INT PRIMARY KEY, val INT);'],
+            ['INSERT INTO t1 (id, val) VALUES (1, 10), (2, 20);'],
+        )
+        catalog = dataset.catalog
+        q_ok = Query('SELECT * FROM t1 WHERE val > 5', catalog=catalog)
+        q_empty = Query('SELECT * FROM t1 WHERE val > 100', catalog=catalog)
+        exercises = [
+            Exercise(
+                title='OK',
+                request='r1',
+                solutions=[q_ok],
+                difficulty=DifficultyLevel.EASY,
+                error=SqlErrors.SYN_1_OMITTING_CORRELATION_NAMES,
+            ),
+            Exercise(
+                title='Empty',
+                request='r2',
+                solutions=[q_empty],
+                difficulty=DifficultyLevel.EASY,
+                error=SqlErrors.SYN_1_OMITTING_CORRELATION_NAMES,
+            ),
+        ]
+        assignment = Assignment(dataset=dataset, exercises=exercises)
+        results = validate_assignment(assignment, 'postgres')
+        assert len(results) == 2
+        assert results[0][1].has_results
+        assert not results[1][1].has_results

--- a/tests/test_query_executor.py
+++ b/tests/test_query_executor.py
@@ -1,6 +1,6 @@
 import pytest
+from unittest.mock import patch, MagicMock
 from sql_assignment_generator.query_executor import (
-    create_db,
     execute_query,
     validate_assignment,
     ExecutionResult,
@@ -9,6 +9,7 @@ from sql_assignment_generator.assignments import Assignment, Dataset, Exercise
 from sql_assignment_generator.difficulty_level import DifficultyLevel
 from sql_error_taxonomy import SqlErrors
 from sqlscope import Query
+from sql_assignment_generator.db.exceptions import QueryExecutionError
 
 
 def _make_dataset(create_sqls: list[str], insert_sqls: list[str]) -> Dataset:
@@ -20,55 +21,25 @@ def _make_dataset(create_sqls: list[str], insert_sqls: list[str]) -> Dataset:
 
 
 # =================================================================
-# CREATE DB
+# EXECUTION RESULT
 # =================================================================
 
-class TestCreateDb:
+class TestExecutionResult:
 
-    def test_basic_schema_and_data(self):
-        dataset = _make_dataset(
-            ['CREATE TABLE t1 (id INT PRIMARY KEY, name VARCHAR);'],
-            ["INSERT INTO t1 (id, name) VALUES (1, 'Alice'), (2, 'Bob');"],
-        )
-        conn = create_db(dataset, 'postgres')
-        rows = conn.execute('SELECT * FROM t1').fetchall()
-        conn.close()
-        assert len(rows) == 2
-        assert rows[0] == (1, 'Alice')
+    def test_has_results_true(self):
+        r = ExecutionResult(rows=[(1,)])
+        assert r.has_results
+        assert r.success
 
-    def test_multiple_tables(self):
-        dataset = _make_dataset(
-            [
-                'CREATE TABLE t1 (id INT PRIMARY KEY);',
-                'CREATE TABLE t2 (id INT PRIMARY KEY, name VARCHAR);',
-            ],
-            [
-                'INSERT INTO t1 (id) VALUES (1), (2);',
-                "INSERT INTO t2 (id, name) VALUES (1, 'x'), (2, 'y');",
-            ],
-        )
-        conn = create_db(dataset, 'postgres')
-        t1_rows = conn.execute('SELECT * FROM t1').fetchall()
-        t2_rows = conn.execute('SELECT * FROM t2').fetchall()
-        conn.close()
-        assert len(t1_rows) == 2
-        assert len(t2_rows) == 2
+    def test_has_results_false_empty(self):
+        r = ExecutionResult(rows=[])
+        assert not r.has_results
+        assert r.success
 
-    def test_foreign_key(self):
-        dataset = _make_dataset(
-            [
-                'CREATE TABLE dept (id INT PRIMARY KEY, name VARCHAR);',
-                'CREATE TABLE emp (id INT PRIMARY KEY, dept_id INT REFERENCES dept(id));',
-            ],
-            [
-                "INSERT INTO dept (id, name) VALUES (1, 'Engineering');",
-                "INSERT INTO emp (id, dept_id) VALUES (1, 1), (2, 1);",
-            ],
-        )
-        conn = create_db(dataset, 'postgres')
-        rows = conn.execute('SELECT * FROM emp').fetchall()
-        conn.close()
-        assert len(rows) == 2
+    def test_has_results_false_error(self):
+        r = ExecutionResult(rows=[], error='some error')
+        assert not r.has_results
+        assert not r.success
 
 
 # =================================================================
@@ -78,71 +49,26 @@ class TestCreateDb:
 class TestExecuteQuery:
 
     def test_returns_results(self):
-        dataset = _make_dataset(
-            ['CREATE TABLE t1 (id INT PRIMARY KEY, val INT);'],
-            ['INSERT INTO t1 (id, val) VALUES (1, 10), (2, 20), (3, 30);'],
-        )
-        conn = create_db(dataset, 'postgres')
-        result = execute_query(conn, 'SELECT * FROM t1 WHERE val > 15', 'postgres')
-        conn.close()
+        db = MagicMock()
+        db.execute.return_value = [(1, 10), (2, 20)]
+        result = execute_query(db, 'SELECT * FROM t1')
         assert result.success
         assert result.has_results
         assert len(result.rows) == 2
 
     def test_returns_empty(self):
-        dataset = _make_dataset(
-            ['CREATE TABLE t1 (id INT PRIMARY KEY, val INT);'],
-            ['INSERT INTO t1 (id, val) VALUES (1, 10), (2, 20);'],
-        )
-        conn = create_db(dataset, 'postgres')
-        result = execute_query(conn, 'SELECT * FROM t1 WHERE val > 100', 'postgres')
-        conn.close()
+        db = MagicMock()
+        db.execute.return_value = []
+        result = execute_query(db, 'SELECT * FROM t1 WHERE val > 100')
         assert result.success
         assert not result.has_results
-        assert len(result.rows) == 0
 
     def test_query_error(self):
-        dataset = _make_dataset(
-            ['CREATE TABLE t1 (id INT PRIMARY KEY);'],
-            ['INSERT INTO t1 (id) VALUES (1);'],
-        )
-        conn = create_db(dataset, 'postgres')
-        result = execute_query(conn, 'SELECT * FROM nonexistent_table', 'postgres')
-        conn.close()
+        db = MagicMock()
+        db.execute.side_effect = QueryExecutionError('table not found')
+        result = execute_query(db, 'SELECT * FROM nonexistent')
         assert not result.success
         assert result.error is not None
-
-    def test_columns_returned(self):
-        dataset = _make_dataset(
-            ['CREATE TABLE t1 (id INT PRIMARY KEY, name VARCHAR);'],
-            ["INSERT INTO t1 (id, name) VALUES (1, 'Alice');"],
-        )
-        conn = create_db(dataset, 'postgres')
-        result = execute_query(conn, 'SELECT id, name FROM t1', 'postgres')
-        conn.close()
-        assert result.columns == ['id', 'name']
-
-
-# =================================================================
-# EXECUTION RESULT
-# =================================================================
-
-class TestExecutionResult:
-
-    def test_has_results_true(self):
-        r = ExecutionResult(rows=[(1,)], columns=['id'])
-        assert r.has_results
-        assert r.success
-
-    def test_has_results_false_empty(self):
-        r = ExecutionResult(rows=[], columns=[])
-        assert not r.has_results
-        assert r.success
-
-    def test_has_results_false_error(self):
-        r = ExecutionResult(rows=[], columns=[], error='some error')
-        assert not r.has_results
-        assert not r.success
 
 
 # =================================================================
@@ -151,7 +77,8 @@ class TestExecutionResult:
 
 class TestValidateAssignment:
 
-    def test_all_exercises_return_results(self):
+    @patch('sql_assignment_generator.query_executor.get_database')
+    def test_all_exercises_return_results(self, mock_get_db):
         dataset = _make_dataset(
             ['CREATE TABLE t1 (id INT PRIMARY KEY, val INT);'],
             ['INSERT INTO t1 (id, val) VALUES (1, 10), (2, 20);'],
@@ -166,12 +93,20 @@ class TestValidateAssignment:
             error=SqlErrors.SYN_1_OMITTING_CORRELATION_NAMES,
         )
         assignment = Assignment(dataset=dataset, exercises=[exercise])
-        results = validate_assignment(assignment, 'postgres')
+
+        mock_db = MagicMock()
+        mock_db.execute.return_value = [(1, 10), (2, 20)]
+        mock_db.__enter__ = MagicMock(return_value=mock_db)
+        mock_db.__exit__ = MagicMock(return_value=False)
+        mock_get_db.return_value = mock_db
+
+        results = validate_assignment(assignment, 'postgres', 'h', 5432, 'u', 'p')
         assert len(results) == 1
         _, result = results[0]
         assert result.has_results
 
-    def test_exercise_returns_no_results(self):
+    @patch('sql_assignment_generator.query_executor.get_database')
+    def test_exercise_returns_no_results(self, mock_get_db):
         dataset = _make_dataset(
             ['CREATE TABLE t1 (id INT PRIMARY KEY, val INT);'],
             ['INSERT INTO t1 (id, val) VALUES (1, 10), (2, 20);'],
@@ -186,13 +121,22 @@ class TestValidateAssignment:
             error=SqlErrors.SYN_1_OMITTING_CORRELATION_NAMES,
         )
         assignment = Assignment(dataset=dataset, exercises=[exercise])
-        results = validate_assignment(assignment, 'postgres')
+
+        mock_db = MagicMock()
+        # First call loads dataset, second call executes query returning empty
+        mock_db.execute.side_effect = [None, []]
+        mock_db.__enter__ = MagicMock(return_value=mock_db)
+        mock_db.__exit__ = MagicMock(return_value=False)
+        mock_get_db.return_value = mock_db
+
+        results = validate_assignment(assignment, 'postgres', 'h', 5432, 'u', 'p')
         assert len(results) == 1
         _, result = results[0]
         assert result.success
         assert not result.has_results
 
-    def test_multiple_exercises_mixed(self):
+    @patch('sql_assignment_generator.query_executor.get_database')
+    def test_multiple_exercises_mixed(self, mock_get_db):
         dataset = _make_dataset(
             ['CREATE TABLE t1 (id INT PRIMARY KEY, val INT);'],
             ['INSERT INTO t1 (id, val) VALUES (1, 10), (2, 20);'],
@@ -217,7 +161,44 @@ class TestValidateAssignment:
             ),
         ]
         assignment = Assignment(dataset=dataset, exercises=exercises)
-        results = validate_assignment(assignment, 'postgres')
+
+        mock_db = MagicMock()
+        # 1st call: dataset load, 2nd: q_ok returns rows, 3rd: q_empty returns empty
+        mock_db.execute.side_effect = [None, [(1, 10), (2, 20)], []]
+        mock_db.__enter__ = MagicMock(return_value=mock_db)
+        mock_db.__exit__ = MagicMock(return_value=False)
+        mock_get_db.return_value = mock_db
+
+        results = validate_assignment(assignment, 'postgres', 'h', 5432, 'u', 'p')
         assert len(results) == 2
         assert results[0][1].has_results
         assert not results[1][1].has_results
+
+    @patch('sql_assignment_generator.query_executor.get_database')
+    def test_dataset_load_failure(self, mock_get_db):
+        dataset = _make_dataset(
+            ['CREATE TABLE t1 (id INT PRIMARY KEY);'],
+            ['INSERT INTO t1 (id) VALUES (1);'],
+        )
+        catalog = dataset.catalog
+        query = Query('SELECT * FROM t1', catalog=catalog)
+        exercise = Exercise(
+            title='Test',
+            request='r',
+            solutions=[query],
+            difficulty=DifficultyLevel.EASY,
+            error=SqlErrors.SYN_1_OMITTING_CORRELATION_NAMES,
+        )
+        assignment = Assignment(dataset=dataset, exercises=[exercise])
+
+        mock_db = MagicMock()
+        mock_db.execute.side_effect = QueryExecutionError('schema error')
+        mock_db.__enter__ = MagicMock(return_value=mock_db)
+        mock_db.__exit__ = MagicMock(return_value=False)
+        mock_get_db.return_value = mock_db
+
+        results = validate_assignment(assignment, 'postgres', 'h', 5432, 'u', 'p')
+        assert len(results) == 1
+        _, result = results[0]
+        assert not result.success
+        assert 'Dataset failed to load' in result.error


### PR DESCRIPTION
Generated SQL exercises sometimes contain queries that return zero rows against the dataset, despite the LLM prompt requesting "executable with minimum 1 returned row." Now adds a post-generation validation step that executes every exercise query in an in-memory SQLite database. If a query returns no results, the LLM is asked to regenerate sample data, which is then verified against the failing query and all other queries.